### PR TITLE
Potential fix for code scanning alert no. 1613: Environment variable built from user-controlled sources

### DIFF
--- a/.github/workflows/release-native-bundle.yml
+++ b/.github/workflows/release-native-bundle.yml
@@ -238,6 +238,11 @@ jobs:
             BRANCH="${{ github.ref_name }}"
             COMMIT="${{ github.sha }}"
           fi
+          # Validate branch format to prevent env injection and invalid refs
+          if [ -z "$BRANCH" ] || [[ "$BRANCH" == *$'\n'* ]] || [[ "$BRANCH" == *$'\r'* ]] || [[ ! "$BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "::error::Invalid branch format: $BRANCH"
+            exit 1
+          fi
           # Validate commit SHA format to prevent env injection
           if [[ ! "$COMMIT" =~ ^[0-9a-f]{7,40}$ ]]; then
             echo "::error::Invalid commit SHA format: $COMMIT"
@@ -263,7 +268,9 @@ jobs:
           # Override commit SHA for the build. GITHUB_SHA is a built-in GitHub Actions
           # env var that cannot be reliably overridden via $GITHUB_ENV. Instead, set
           # WORKFLOW_GITHUB_SHA which takes priority in platformEnv.githubSHA.
-          sed -i "s/^GITHUB_SHA=.*/GITHUB_SHA=$COMMIT/" .env
+          grep -v '^GITHUB_SHA=' .env > .env.tmp || true
+          printf 'GITHUB_SHA=%s\n' "$COMMIT" >> .env.tmp
+          mv .env.tmp .env
           echo "GITHUB_SHA=$COMMIT" >> $GITHUB_ENV
           echo "WORKFLOW_GITHUB_SHA=$COMMIT" >> $GITHUB_ENV
           echo "WORKFLOW_GITHUB_SHA=$COMMIT" >> .env


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/app-monorepo/security/code-scanning/1613](https://github.com/Dargon789/app-monorepo/security/code-scanning/1613)

To fix this without changing intended functionality, validate both user-influenced values before writing them to `$GITHUB_ENV`, and avoid unsafe text replacement with unescaped user data.

Best single approach in this file:
1. In **`.github/workflows/release-native-bundle.yml`**, inside step **“Resolve branch and commit”** (`run` block around lines 233–270):
   - Add strict validation for `BRANCH` (reject empty, newline/carriage return, and non-ref-safe chars; optionally allow `/`, `.`, `_`, `-`).
   - Keep existing SHA validation for `COMMIT`.
   - Continue using UUID-delimited multiline env writes.
2. Replace `sed -i "s/^GITHUB_SHA=.*/GITHUB_SHA=$COMMIT/" .env` with a safe write pattern that does not interpolate unescaped user input into `sed` replacement (e.g., rebuild `.env` line via `grep -v` + `printf` append).

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Harden the release-native-bundle GitHub Actions workflow against environment injection and unsafe handling of user-influenced values.

Bug Fixes:
- Validate the resolved branch name to reject empty, newline-containing, or invalid ref-like values before writing it to the GitHub Actions environment.
- Replace the inline sed substitution of GITHUB_SHA in .env with a safer reconstruction of the file that appends a validated SHA value.

CI:
- Tighten input validation and env file handling in the release-native-bundle workflow step that resolves branch and commit metadata.